### PR TITLE
Recon launch compatible builds with tagger ID in REST and halld_sim 4…

### DIFF
--- a/recon-2017_01-ver03_25.xml
+++ b/recon-2017_01-ver03_25.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://halldweb.jlab.org/dist/version4.xsl"?>
+<gversions file="recon-2017_01-ver03_25.xml" date="2021-04-08">
+<description>Latest simulation with recon-2017_01-ver03.4 which has tagger hit ID in REST.</description>
+<package name="amptools" version="0.11.0"/>
+<package name="ccdb" version="1.06.07"/>
+<package name="cernlib" version="2005" word_length="64-bit"/>
+<package name="diracxx" version="1.0.0"/>
+<package name="evio" version="4.4.6"/>
+<package name="evtgen" version="01.07.00"/>
+<package name="geant4" version="10.02.p02"/>
+<package name="gluex_MCwrapper" version="v2.5.1"/>
+<package name="gluex_root_analysis" version="1.17.0" dirtag="rec1701"/>
+<package name="halld_recon" version="recon-2017_01-ver03.4"/>
+<package name="halld_sim" version="4.29.0" dirtag="rec1701"/>
+<package name="hdds" version="4.6.0"/>
+<package name="hdgeant4" version="2.21.0" dirtag="rec1701"/>
+<package name="hd_utilities" version="1.30"/>
+<package name="hepmc" version="2.06.10"/>
+<package name="jana" version="0.7.9p1" dirtag="ccdb167"/>
+<package name="lapack" version="3.6.0"/>
+<package name="photos" version="3.61"/>
+<package name="rcdb" version="0.06.00"/>
+<package name="root" version="6.08.06"/>
+<package name="sqlitecpp" version="2.2.0" dirtag="bs130"/>
+<package name="sqlite" version="3.13.0" year="2016" dirtag="bs130"/>
+<package name="xerces-c" version="3.1.4"/>
+</gversions>

--- a/recon-2018_01-ver02_17.xml
+++ b/recon-2018_01-ver02_17.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://halldweb.jlab.org/dist/version4.xsl"?>
+<gversions file="recon-2018_01-ver02_17.xml" date="2021-04-08">
+<description>Latest simulation with recon-2018_01-ver02.3 which has tagger hit ID in REST.</description>
+<package name="amptools" version="0.11.0"/>
+<package name="ccdb" version="1.06.07"/>
+<package name="cernlib" version="2005" word_length="64-bit"/>
+<package name="diracxx" version="1.0.0"/>
+<package name="evio" version="4.4.6"/>
+<package name="evtgen" version="01.07.00"/>
+<package name="geant4" version="10.02.p02"/>
+<package name="gluex_MCwrapper" version="v2.5.1"/>
+<package name="gluex_root_analysis" version="1.17.0" dirtag="rec1801"/>
+<package name="halld_recon" version="recon-2018_01-ver02.3"/>
+<package name="halld_sim" version="4.29.0" dirtag="rec1801"/>
+<package name="hdds" version="4.6.0"/>
+<package name="hdgeant4" version="2.21.0" dirtag="rec1801"/>
+<package name="hd_utilities" version="1.30"/>
+<package name="hepmc" version="2.06.10"/>
+<package name="jana" version="0.7.9p1" dirtag="ccdb167"/>
+<package name="lapack" version="3.6.0"/>
+<package name="photos" version="3.61"/>
+<package name="rcdb" version="0.06.00"/>
+<package name="root" version="6.08.06"/>
+<package name="sqlitecpp" version="2.2.0" dirtag="bs130"/>
+<package name="sqlite" version="3.13.0" year="2016" dirtag="bs130"/>
+<package name="xerces-c" version="3.1.4"/>
+</gversions>

--- a/recon-2018_08-ver02_16.xml
+++ b/recon-2018_08-ver02_16.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://halldweb.jlab.org/dist/version4.xsl"?>
+<gversions file="recon-2018_08-ver02_16.xml" date="2021-04-08">
+<description>Latest simulation with recon-2018_08-ver02.3 which has tagger hit ID in REST.</description>
+<package name="amptools" version="0.11.0"/>
+<package name="ccdb" version="1.06.07"/>
+<package name="cernlib" version="2005" word_length="64-bit"/>
+<package name="diracxx" version="1.0.0"/>
+<package name="evio" version="4.4.6"/>
+<package name="evtgen" version="01.07.00"/>
+<package name="geant4" version="10.02.p02"/>
+<package name="gluex_MCwrapper" version="v2.5.1"/>
+<package name="gluex_root_analysis" version="1.17.0" dirtag="rec1808"/>
+<package name="halld_recon" version="recon-2018_08-ver02.3"/>
+<package name="halld_sim" version="4.29.0" dirtag="rec1808"/>
+<package name="hdds" version="4.6.0"/>
+<package name="hdgeant4" version="2.21.0" dirtag="rec1808"/>
+<package name="hd_utilities" version="1.30"/>
+<package name="hepmc" version="2.06.10"/>
+<package name="jana" version="0.7.9p1" dirtag="ccdb167"/>
+<package name="lapack" version="3.6.0"/>
+<package name="photos" version="3.61"/>
+<package name="rcdb" version="0.06.00"/>
+<package name="root" version="6.08.06"/>
+<package name="sqlitecpp" version="2.2.0" dirtag="bs130"/>
+<package name="sqlite" version="3.13.0" year="2016" dirtag="bs130"/>
+<package name="xerces-c" version="3.1.4"/>
+</gversions>


### PR DESCRIPTION
….29.0 et al. for simulation.